### PR TITLE
Updated request public to send current userID

### DIFF
--- a/core-ble/src/main/java/com/example/disastermesh/core/ble/encodeRequestPubKey.kt
+++ b/core-ble/src/main/java/com/example/disastermesh/core/ble/encodeRequestPubKey.kt
@@ -1,6 +1,0 @@
-package com.example.disastermesh.core.ble
-
-import com.example.disastermesh.core.data.MessageCodec
-
-fun encodeRequestPubKey(uid: Int): ByteArray =
-    MessageCodec.encodeRequestPubKey(uid)

--- a/core-ble/src/main/java/com/example/disastermesh/core/ble/repository/BleMeshRepository.kt
+++ b/core-ble/src/main/java/com/example/disastermesh/core/ble/repository/BleMeshRepository.kt
@@ -83,8 +83,8 @@ class BleMeshRepository @Inject constructor(
 
     override fun publicKeyFlow(userId: Int) = pkDao.keyFlow(userId)
 
-    override suspend fun requestPublicKey(userId: Int) {
-        gatt.sendMessage(MessageCodec.encodeRequestPubKey(userId))
+    override suspend fun requestPublicKey(targetUid: Int, myUserId: Int) {
+        gatt.sendMessage(MessageCodec.encodeRequestPubKey(targetUid, myUserId))
     }
 
     /* ---------- encryption flag helpers --------------------------- */

--- a/core-ble/src/main/java/com/example/disastermesh/core/ble/repository/MeshRepository.kt
+++ b/core-ble/src/main/java/com/example/disastermesh/core/ble/repository/MeshRepository.kt
@@ -26,7 +26,7 @@ interface MeshRepository {
 
     /* -------- new key-management API ------------------------------- */
     fun publicKeyFlow(userId: Int): Flow<ByteArray?>
-    suspend fun requestPublicKey(userId: Int)
+    suspend fun requestPublicKey(targetUid: Int, myUserId: Int)
 
     /* -------- per-chat encryption flag ----------------------------- */
     fun encryptedFlow(chatId: Long): Flow<Boolean>

--- a/core-data/src/main/java/com/example/disastermesh/core/data/MessageCodec.kt
+++ b/core-data/src/main/java/com/example/disastermesh/core/data/MessageCodec.kt
@@ -72,13 +72,13 @@ object MessageCodec {
         encode(cm).also { it[0] = Opcode.USER_MSG_GATEWAY.id.toByte() }
 
 
-    fun encodeRequestPubKey(targetUid: Int): ByteArray =
+    fun encodeRequestPubKey(targetUid: Int, myUid: Int): ByteArray =
         ByteBuffer.allocate(1 + 4 + 4)             // header only
             .order(ByteOrder.LITTLE_ENDIAN)
             .apply {
                 put(Opcode.BLE_REQUEST_PUBKEY.id.toByte())
                 putInt(targetUid)      // dest = user we need the key for
-                putInt(0)              // sender = 0   (ignored by node)
+                putInt(myUid)              // sender = our userID
             }.array()
 
     fun encodeAnnounceKey(myUid: Int, pk32: ByteArray): ByteArray =

--- a/feature-ble/src/main/java/com/example/disastermesh/feature/ble/BleChatViewModel.kt
+++ b/feature-ble/src/main/java/com/example/disastermesh/feature/ble/BleChatViewModel.kt
@@ -2,6 +2,7 @@ package com.example.disastermesh.feature.ble
 
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -65,7 +66,21 @@ class BleChatViewModel @Inject constructor(
     }
 
     fun requestKey() = viewModelScope.launch {
-        targetUidFlow.first()?.let { bleRepo.requestPublicKey(it) }  //TODO was previously targetUidFlow.value
+        val cid = chatId.value ?: return@launch
+        val currentType  = idType(cid)
+
+        // Very defensive code
+        if (currentType != MessageType.USER) {
+            Log.w("BleChatViewModel", "requestKey called for non-USER message type: $currentType")
+            return@launch
+        }
+
+        val myUid = uidFlow.value ?: run {
+            Log.e("BleChatViewModel", "requestKey: uidFlow.value is null for a USER message.")
+            return@launch
+        }
+
+        targetUidFlow.first()?.let { targetUid -> bleRepo.requestPublicKey(targetUid, myUid) }
     }
 
     init {


### PR DESCRIPTION
This pull request refactors the public key request functionality in the BLE module to include the sender's user ID (`myUserId`) in addition to the target user ID (`targetUid`). It also introduces defensive programming practices in the `BleChatViewModel` to handle edge cases and improve logging.

### Refactoring of Public Key Request API:
* [`core-data/src/main/java/com/example/disastermesh/core/data/MessageCodec.kt`](diffhunk://#diff-cc3adddd7c1bd28fa952637123f4b21777ee87e2ea8c8b8b4b774850442878c2L75-R81): Updated the `encodeRequestPubKey` method to accept both `targetUid` and `myUid`, replacing the hardcoded sender ID with the actual user ID.
* [`core-ble/src/main/java/com/example/disastermesh/core/ble/repository/MeshRepository.kt`](diffhunk://#diff-164f7e84c2ff28b1c8a24181cb6a350dc6ea01bc84158d8adcc0251f08a1649dL29-R29): Updated the `requestPublicKey` method signature to include `targetUid` and `myUserId`.
* [`core-ble/src/main/java/com/example/disastermesh/core/ble/repository/BleMeshRepository.kt`](diffhunk://#diff-678e314419c6eeff5cbb9a93be7600121fbba79a295ed173d854f17ef3edd6dfL86-R87): Updated the implementation of `requestPublicKey` to pass both `targetUid` and `myUserId` to the `MessageCodec.encodeRequestPubKey` method.
* [`core-ble/src/main/java/com/example/disastermesh/core/ble/encodeRequestPubKey.kt`](diffhunk://#diff-12ff2f86e0d315397e78cc909dd50d5af016a36dbb482770c1bbb367b2de059dL1-L6): Removed the now-unused standalone `encodeRequestPubKey` function.
